### PR TITLE
Patch: fail on non 200 terraform api

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ ORG_NAME=$3
 
 WORKSPACE_DATA=$(
     curl \
+        --fail \
         --header "Authorization: Bearer $TF_TOKEN" \
         --header "Content-Type: application/vnd.api+json" \
         "https://app.terraform.io/api/v2/organizations/$ORG_NAME/workspaces/$WORKSPACE_NAME"
@@ -16,6 +17,7 @@ WORKSPACE_ID=$(echo "$WORKSPACE_DATA" | jq -r '.data.id')
 NEW_RUN_DATA="{\"data\": {\"type\": \"runs\", \"relationships\": {\"workspace\": {\"data\": {\"id\": \"$WORKSPACE_ID\"}}}, \"attributes\": {\"message\": \"Automated run from ${GITHUB_REPOSITORY} github action.\"}}}"
 
 curl \
+  --fail \
   --header "Authorization: Bearer $TF_TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \

--- a/readme.md
+++ b/readme.md
@@ -23,12 +23,26 @@ with:
   org-name: ${{ env.ORG_NAME }}
 ```
 
-## Development
+## Release
 
 ```
 # git add as per usual
 
-git tag -a -m 'Thousands of gyms. Zero contracts.' v1
-git push --follow-tags
+git tag -a -m 'Thousands of gyms. Zero contracts.' v1.1
+git push origin v1.1
 ```
 
+#### Gotcha
+> GitHub actions currently are only resolving to exact versioning. Meaning for a new patch release you'll have to overwrite the current minor release with it.
+
+```
+# This is just for logging purposes, and is not actually used.
+git tag -a -m 'Thousands of gyms. Zero contracts.' v1.2.3
+git push origin v1.2.3
+
+# Version Used by clients
+git tag --delete v1.2
+git push origin --delete v1.2
+git tag -a -m 'Patch release message' v1.2
+git push origin v1.2
+```


### PR DESCRIPTION
There have been quite a few cases where our github actions have been failing siliently. Cases where terraform API responds with 404, and yet the relevant github action not failing. 

This PR fixes that. 

Resolves https://github.com/HussleHQ/terraform-cloud-trigger-run/issues/1